### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ erlang app called `observer` which has been included in Grapherl.
 
 ### Handling large number of metrics
 In case you want to track a lot of metrics graph_db allows the user to bootstrap ram and disk db objects
-for metrics before any data starts coming in. Doing this will be helpful becasue creating ram and disk db objects is
+for metrics before any data starts coming in. Doing this will be helpful because creating ram and disk db objects is
 a time consuming task, so while receiving such huge traffic it is advisible that the user bootstrap some of the metrics
 so that the system doesn't fall under sudden load (though the app can handle sudden loads it just to assure constant cpu usage).
 In order to bootstrap metric user needs have a file in the following format:


### PR DESCRIPTION
@processone, I've corrected a typographical error in the documentation of the [grapherl](https://github.com/processone/grapherl) project. Specifically, I've changed becasue to because. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
